### PR TITLE
fix(renderer): remove sourcemap info from table element

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -71,7 +71,7 @@ export class Parser {
                             sourceMapLineStart ? sourceMapLineStart + 2 + j : undefined,
                         );
                     }
-                    out += this.renderer.table(header, body, token.sourceMap);
+                    out += this.renderer.table(header, body);
                     continue;
                 }
                 case "blockquote": {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -80,17 +80,9 @@ export class Renderer {
         return `<p${renderSourceMap(sourceMap)}>${text}</p>\n`;
     }
 
-    table(header: string, body: string, sourceMap: SourceMap): string {
+    table(header: string, body: string): string {
         if (body) body = `<tbody>${body}</tbody>`;
-
-        return (
-            `<table${renderSourceMap(sourceMap)}>\n` +
-            "<thead>\n" +
-            header +
-            "</thead>\n" +
-            body +
-            "</table>\n"
-        );
+        return "<table>\n" + "<thead>\n" + header + "</thead>\n" + body + "</table>\n";
     }
 
     tablerow(content: string, sourceMapStart: number | undefined): string {


### PR DESCRIPTION
table rows include their own sourcemap info, sourcemap info in parent table element is unnecessary