### PR TITLE
fix(footnotes): footnotes support links

### DIFF
--- a/src/rules/block.ts
+++ b/src/rules/block.ts
@@ -126,6 +126,6 @@ export const block: Record<BlockRuleNames, RegExp> = {
     table: block_table,
     lheading: block_lheading,
     paragraph: block_paragraph,
-    footnote: /^\[\^([^\]\n]+)\]:(?:[ \t]+|[\n]*?|$)([^\[\n]*?(?:\n|$)(?:[\n]*?[ ]{4,}[^\[\n]*)*)/,
+    footnote: /^\[\^([^\]\n]+)\]:(?:[ \t]+|[\n]*?|$)([^\n]*?(?:\n|$)(?:[\n]*?[ ]{4,}[^\n]*)*)/,
     text: /^[^\n]+/,
 };


### PR DESCRIPTION
Previously, links in a footnote would not be caught by the regex and thus the resulting markdown would be all messed up.

fix #74