### PR TITLE
feat: return separate html & javascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 Pantsdown is a **Markdown** to **HTML** converter. It attempts to render markdown similar to how GitHub does it plus
 some features developed specifically for [github-preview.nvim](https://github.com/wallpants/github-preview.nvim).
 
-If you need a feature that's supported by GitHub and is not already listed in the [Roadmap](#-roadmap),
-feel free to open an issue.
-
 ## [▶️ Demo](https://wallpants.github.io/pantsdown/)
 
 ## 📦 Installation
@@ -32,7 +29,9 @@ it's recommended you use a sanitization library like [DOMPurify](https://github.
 ### Styles
 
 For styles to be properly applied, either the element containing the generated html or one of its parents
-must have the classes `class="pantsdown light"` or `class="pantsdown dark"` added.
+must have the classes `class="pantsdown light"` or `class="pantsdown dark"` added. You can also add
+the class `"high-contrast"` to enable high-contrast themes `class="pantsdown dark high-contrast"` or
+`class="pantsdown light high-contrast"`.
 
 ### [Bun](https://bun.sh/)
 
@@ -74,16 +73,22 @@ import { useEffect } from "react";
 const pantsdown = new Pantsdown();
 
 function App() {
-    useEffect(() => {
-        const markdown = "# Hello world\n- [ ] Task 1\n- [x] Task 2";
-        const html = pantsdown.parse(markdown);
-        const container = document.getElementById("markdown-container");
-        if (container) container.innerHTML = html;
-    }, []);
+  useEffect(() => {
+    const container = document.getElementById("markdown-container");
+    if (!container) return;
 
-    // ⚠️ for styles to be applied, a parent element must have
-    // the classes "pantsdown light" or "pantsdown dark" added
-    return <div id="markdown-container" className="pantsdown light" />;
+    const markdown = "# Hello world\n- [ ] Task 1\n- [x] Task 2";
+    const { html, javascript } = pantsdown.parse(markdown);
+    container.innerHTML = html;
+
+    const newScript = document.createElement("script");
+    newScript.text = javascript;
+    container.appendChild(newScript);
+  }, []);
+
+  // ⚠️ for styles to be applied, a parent element must have
+  // the classes "pantsdown light" or "pantsdown dark" added
+  return <div id="markdown-container" className="pantsdown light" />;
 }
 
 export default App;
@@ -100,32 +105,32 @@ import { Pantsdown, type PartialPantsdownConfig } from "pantsdown";
 // This is the default config object. If you provide
 // a config object, it will be deeply merged into this.
 const config: PartialPantsdownConfig = {
-    renderer: {
-        /**
-         * Prefix to be added to relative image sources.
-         * Must start and end with "/"
-         *
-         * @example
-         * relativeImageUrlPrefix: "/__localimage__/"
-         *
-         * ![image](./wallpants-512.png)
-         * relative src is updated and results in:
-         * <img src="/__localimage__/wallpants-512.png" />
-         *
-         * ![image](https://avatars.githubusercontent.com/wallpants)
-         * absolute src remains unchanged:
-         * <img src="https://avatars.githubusercontent.com/wallpants" />
-         */
-        relativeImageUrlPrefix: "",
+  renderer: {
+    /**
+     * Prefix to be added to relative image sources.
+     * Must start and end with "/"
+     *
+     * @example
+     * relativeImageUrlPrefix: "/__localimage__/"
+     *
+     * ![image](./wallpants-512.png)
+     * relative src is updated and results in:
+     * <img src="/__localimage__/wallpants-512.png" />
+     *
+     * ![image](https://avatars.githubusercontent.com/wallpants)
+     * absolute src remains unchanged:
+     * <img src="https://avatars.githubusercontent.com/wallpants" />
+     */
+    relativeImageUrlPrefix: "",
 
-        /**
-         * Whether to render <details> html tags with attribute open=""
-         *
-         * @default
-         * false
-         */
-        detailsTagDefaultOpen: false,
-    },
+    /**
+     * Whether to render <details> html tags with attribute open=""
+     *
+     * @default
+     * false
+     */
+    detailsTagDefaultOpen: false,
+  },
 };
 
 const pantsdown = new Pantsdown(config);

--- a/docs/build.ts
+++ b/docs/build.ts
@@ -13,7 +13,7 @@ const cssPath = import.meta.dir + "/../src/css/styles.css";
 const css = await Bun.file(cssPath).text();
 
 const pantsdown = new Pantsdown();
-const html = pantsdown.parse(readme + features);
+const { html, javascript } = pantsdown.parse(readme + features);
 
 const index = (theme: "dark" | "light") => `<!doctype html>
 <html lang="en" class="pantsdown ${theme}">
@@ -21,6 +21,7 @@ const index = (theme: "dark" | "light") => `<!doctype html>
         <meta charset="utf-8" />
         <link href="wallpants-128.png" rel="icon" type="image/png" />
         <style>${css}</style>
+        <script type="module">${javascript}</script>
         <script type="module">
             import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
             mermaid.initialize({

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -1,5 +1,5 @@
-export const codeCopyScript = `
-<script id="code-copy-script" type="module">
+export const javascript = `
+    /** code copy button */
     document.querySelectorAll("pre").forEach((pre) => {
         const firstElement = pre.firstElementChild;
         if (!firstElement || firstElement.tagName !== "CODE") return;
@@ -15,17 +15,21 @@ export const codeCopyScript = `
 
         pre.appendChild(copyButton);
         copyButton.addEventListener("click", () => {
-            navigator.clipboard.writeText(pre.firstChild.textContent)
-                .then(
-                    () => {
-                        copyButton.classList.add("success");
-                        setTimeout(() => {
-                            copyButton.classList.remove("success");
-                        }, 1000);
-                    }
-                );
+            if (!pre.firstChild?.textContent) {
+                return;
+            }
 
+            navigator.clipboard
+                .writeText(pre.firstChild.textContent)
+                .then(() => {
+                    copyButton.classList.add("success");
+                    setTimeout(() => {
+                        copyButton.classList.remove("success");
+                    }, 1000);
+                })
+                .catch(() => {
+                    //
+                });
         });
     });
-</script>
 `;

--- a/src/pantsdown.ts
+++ b/src/pantsdown.ts
@@ -1,5 +1,5 @@
 import GithubSlugger from "github-slugger";
-import { codeCopyScript } from "./code-copy.ts";
+import { javascript } from "./javascript.ts";
 import { Lexer } from "./lexer.ts";
 import { Parser } from "./parser.ts";
 import { type PantsdownConfig, type PartialPantsdownConfig } from "./types.ts";
@@ -38,13 +38,16 @@ export class Pantsdown {
     /**
      * Parse markdown string
      */
-    parse(src: string): string {
+    parse(src: string): { html: string; javascript: string } {
         // re-init slugger to avoid slug count from incorrectly incrementing
         // from previosly slugged headings
         this.parser.renderer.slugger = new GithubSlugger();
 
         const tokens = this.lexer.lex(src);
         const html = this.parser.parse(tokens);
-        return codeCopyScript + html;
+        return {
+            html,
+            javascript,
+        };
     }
 }


### PR DESCRIPTION
pantsdown.parse now returns { html, javascript }. Previously it would return html which included relevant javascript, but in non-static environments (vite) it was cumbersome to get the javascript working. This simplifies that a bit.

BREAKING CHANGE: pantsdown.parse now return `{ html: string; javascript: string; }` instead of only a string.

fix #64 #76