### PR TITLE
ci(release): fix release github-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,4 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: bun run semantic-release
+              run: bun run --bun semantic-release


### PR DESCRIPTION
semantic-release was not getting the node version it was expecting. we're now running "bun run --bun semantic-release" to force the script to run using bun instead of node